### PR TITLE
fix(setup): setup nvim-lsp-installer before interacting with it

### DIFF
--- a/lua/lsp-zero.lua
+++ b/lua/lsp-zero.lua
@@ -28,6 +28,9 @@ local run = function(args)
   local suggest = user_config.suggest_lsp_servers
   local handle_setup = user_config.setup_servers_on_start
 
+  local lsp_install = require('nvim-lsp-installer')
+  util.setup_lsp_installer()
+
   if user_config.manage_nvim_cmp then
     require('lsp-zero.nvim-cmp-setup').call_setup(args.cmp_opts)
   end
@@ -62,9 +65,6 @@ local run = function(args)
 
     configure(server.name, server_opts)
   end
-
-  local lsp_install = require('nvim-lsp-installer')
-  util.setup_lsp_installer()
 
   for _, server in pairs(lsp_install.get_installed_servers()) do
     if handle_setup == true then


### PR DESCRIPTION
Hello! It's important that the setup function is called as early as possible (at the very minimum before any other interactions with  `nvim-lsp-installer`). I haven't debugged this, but just from reviewing the code I believe there's some problematic behavior with how [the `state.sync`](https://github.com/VonHeikemen/lsp-zero.nvim/blob/aed2952d4f6a4b1abb57c116e7c509fee2ba6416/lua/lsp-zero.lua#L43) function is called before setup. There was also an issue [filed here ](https://github.com/williamboman/nvim-lsp-installer/issues/764), which I believe is caused by this