### PR TITLE
Pass through cmp `performance` field

### DIFF
--- a/lua/lsp-zero/nvim-cmp-setup.lua
+++ b/lua/lsp-zero/nvim-cmp-setup.lua
@@ -89,6 +89,7 @@ end
 M.cmp_config = function()
   return {
     sources = M.sources(),
+    performance = M.performance(),
     mapping = M.default_mappings(),
     completion = {
       completeopt = 'menu,menuone,noinsert'


### PR DESCRIPTION
cmp added a `performance` field related to this issue:
https://github.com/hrsh7th/nvim-cmp/issues/598#issuecomment-1159516680.
This commit just passes that through in the cmp_config function.