### PR TITLE
Pass through cmp `performance` field

### DIFF
--- a/lua/lsp-zero.lua
+++ b/lua/lsp-zero.lua
@@ -237,6 +237,10 @@ M.defaults.cmp_sources = function()
   return require('lsp-zero.nvim-cmp-setup').sources()
 end
 
+M.defaults.cmp_performance = function()
+  return require('lsp-zero.nvim-cmp-setup').performance()
+end
+
 M.defaults.cmp_config = function()
   return require('lsp-zero.nvim-cmp-setup').cmp_config()
 end

--- a/lua/lsp-zero/nvim-cmp-setup.lua
+++ b/lua/lsp-zero/nvim-cmp-setup.lua
@@ -93,6 +93,7 @@ M.cmp_config = function()
     completion = {
       completeopt = 'menu,menuone,noinsert'
     },
+    performance = {},
     snippet = {
       expand = function(args)
         luasnip.lsp_expand(args.body)
@@ -137,6 +138,10 @@ M.call_setup = function(opts)
 
   if type(opts.sources) == 'table' then
     config.sources = opts.sources
+  end
+
+  if type(opts.performance) == 'table' then
+    config.performance = opts.performance
   end
 
   if type(opts.mapping) == 'table' then


### PR DESCRIPTION
cmp added a `performance` field related to this issue:
https://github.com/hrsh7th/nvim-cmp/issues/598#issuecomment-1159516680.
This commit just passes that through in the cmp_config function.