### PR TITLE
 feat: allow user to override preselect option in nvim-cmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,8 @@ lsp.nvim_workspace({
 
 * `documentation`: Modifies the look of the documentation window. You can find more details about its properities if you start typing the command `:help cmp-config.window`.
 
+* `preselect`: By default, the first item in the completion menu is preselected. Disable this behaviour by setting this to `cmp.PreselectMode.None`.
+
 * `formatting`: Modifies the look of the completion menu. You can find more details about its properities if you start typing the command `:help cmp-config.formatting`.
 
 * `mapping`: Sets the keybindings. See `:help cmp-mapping`.

--- a/doc/lsp-zero.txt
+++ b/doc/lsp-zero.txt
@@ -618,6 +618,11 @@ Lua API                                                     *lsp-zero-lua-api*
               details about its properities if you start typing the
               command `:help cmp-config.formatting`.
 
+          preselect: ~
+              By default, the first item in the completion menu is preselected.
+              Disable this behaviour by setting this to `cmp.PreselectMode.None`.
+              See |cmp-config.preselect| to know more.
+
           mapping: ~
               Sets the keybindings. See |cmp-mapping|.
 

--- a/lua/lsp-zero/nvim-cmp-setup.lua
+++ b/lua/lsp-zero/nvim-cmp-setup.lua
@@ -89,6 +89,7 @@ end
 M.cmp_config = function()
   return {
     sources = M.sources(),
+    preselect = cmp.PreselectMode.Item,
     mapping = M.default_mappings(),
     completion = {
       completeopt = 'menu,menuone,noinsert'
@@ -158,6 +159,10 @@ M.call_setup = function(opts)
 
   if type(opts.formatting) == 'table' then
     config.formatting = merge(config.formatting, opts.formatting)
+  end
+
+  if opts.preselect ~= nil then
+    config.preselect = opts.preselect
   end
 
   cmp.setup(config)


### PR DESCRIPTION
I know you are adverse to exposing more options, but I hope this one is ok. Think of it as something that should really be one of the `mapping` options. It's critical to have this for certain mapping setups that depend on if the user actively selected something or not.  I got completely stuck without this trying to port over my existing autocomplete behavior. My muscle memory is very confused otherwise.