### PR TITLE
fix: inability to customize nvim-cmp completion window

### DIFF
--- a/lua/lsp-zero/nvim-cmp-setup.lua
+++ b/lua/lsp-zero/nvim-cmp-setup.lua
@@ -181,7 +181,7 @@ M.call_setup = function(opts)
   end
 
   if type(opts.completion) == 'table' then
-    config.completion = merge(config.completion, opts.completion)
+    config.window.completion = opts.completion
   end
 
   if type(opts.formatting) == 'table' then


### PR DESCRIPTION
Related to #125 