### PR TITLE
Force Lazy plugin manager to load lsp-zero first

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ With `lazy.nvim`:
 {
   'VonHeikemen/lsp-zero.nvim',
   branch = 'v1.x',
+  lazy = false,
+  priority = 1000, -- set to highest priority, forcing to load it first
   dependencies = {
     -- LSP Support
     {'neovim/nvim-lspconfig'},             -- Required


### PR DESCRIPTION
The plugin lspconfig does weird things when is not loaded at startup, so this update setting lazy.nvim to run lsp-zero at startup
More information can be found in this thread : https://github.com/VonHeikemen/lsp-zero.nvim/discussions/147