### PR TITLE
fix: missing argument on check.inspect_server_config call

### DIFF
--- a/lua/lsp-zero/check.lua
+++ b/lua/lsp-zero/check.lua
@@ -107,7 +107,7 @@ end
 
 M.inspect_server_config = function(name)
   local util = require('lspconfig.util')
-  local client = util.get_active_client_by_name(name)
+  local client = util.get_active_client_by_name(0, name)
 
   if client == nil then
     local msg = '* "%s" is not active in the current buffer'


### PR DESCRIPTION
Hello. I was getting a validation error
```
E5108: Error executing lua /usr/share/nvim/runtime/lua/vim/lsp.lua:80: bufnr: expected number, got string
stack traceback:
        [C]: in function 'error'
        vim/shared.lua: in function 'validate'
        /usr/share/nvim/runtime/lua/vim/lsp.lua:80: in function 'resolve_bufnr'
        /usr/share/nvim/runtime/lua/vim/lsp.lua:1790: in function 'get_active_clients'
        .../pack/packer/start/nvim-lspconfig/lua/lspconfig/util.lua:552: in function 'get_active_client_by_name'
        ...e/pack/packer/start/lsp-zero.nvim/lua/lsp-zero/check.lua:110: in function 'inspect_server_config'
        [string ":lua"]:1: in main chunk
```
when trying to inspect the server config:
```vim
:lua require('lsp-zero.check').inspect_server_config('tsserver')
```
I know nothing about nvim, but noticed that two calls to `util.get_active_client_by_name` differed a bit. Passing zero as the first argument seemed to solve the problem, but I'm not sure if that's the right solution.