### PR TITLE
feat: add standardrb lsp to filetypes

### DIFF
--- a/lua/lsp-zero/lsp-filetypes.lua
+++ b/lua/lsp-zero/lsp-filetypes.lua
@@ -634,6 +634,9 @@ return {
     mysql = true,
     sql = true
   },
+  standardrb = {
+    ruby = true
+  },
   starlark_rust = {
     ["BUILD.bazel"] = true,
     bzl = true,


### PR DESCRIPTION
Add the standardrb lsp to filetypes so it is started automatically.