### PR TITLE
Make documentation scroll more intuitive

### DIFF
--- a/lua/lsp-zero/cmp-setup.lua
+++ b/lua/lsp-zero/cmp-setup.lua
@@ -204,8 +204,8 @@ end
 
 function M.basic_mappings()
   return {
-    ['<C-u>'] = cmp.mapping.scroll_docs(4),
-    ['<C-d>'] = cmp.mapping.scroll_docs(-4),
+    ['<C-d>'] = cmp.mapping.scroll_docs(4),
+    ['<C-u>'] = cmp.mapping.scroll_docs(-4),
     ['<C-y>'] = cmp.mapping.confirm({select = true}),
     ['<C-e>'] = cmp.mapping.abort(),
     ['<Up>'] = cmp.mapping.select_prev_item(select_opts),


### PR DESCRIPTION
Currently C-u scroll down, C-d scrolls up. This fixes it.