### PR TITLE
fix: formatting would not work if you attempted to format while an error was preent

### DIFF
--- a/lua/lsp-zero/format.lua
+++ b/lua/lsp-zero/format.lua
@@ -313,7 +313,7 @@ function s.request_format(client_id, buffer, format_opts)
   end
 
   vim.b.lsp_zero_changedtick = vim.b.changedtick
-  vim.b.lsp_zero_format_progress = 1
+  vim.b.lsp_zero_format_progress = 0
 
   local params = vim.lsp.util.make_formatting_params(format_opts)
   local client = vim.lsp.get_client_by_id(client_id)


### PR DESCRIPTION
If you attempted to format while an error was present, `request_format` would never execute beyond the `[lsp-zero] A formatting request is already in progress` block.

Because of this, 'request_format' does not properly update `vim.b.lsp_zero_format_progress` and every attempt to format afterwards does not work