### PR TITLE
Update lsp.md to document many prettier filetypes for format on save

### DIFF
--- a/doc/md/lsp.md
+++ b/doc/md/lsp.md
@@ -431,6 +431,8 @@ lsp.format_mapping('gq', {
     ['rust_analyzer'] = {'rust'},
     -- if you have a working setup with null-ls
     -- you can specify filetypes it can format.
+    -- see https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/doc/BUILTINS.md#prettier 
+    -- for a set of filetypes useful for prettier null-ls integration
     -- ['null-ls'] = {'javascript', 'typescript'},
   }
 })

--- a/doc/md/lsp.md
+++ b/doc/md/lsp.md
@@ -315,8 +315,10 @@ lsp.format_on_save({
     ['lua_ls'] = {'lua'},
     ['rust_analyzer'] = {'rust'},
     -- if you have a working setup with null-ls
-    -- you can specify filetypes it can format.
-    -- ['null-ls'] = {'javascript', 'typescript'},
+    -- you can specify filetypes it can format
+    -- for instance with prettier enabled, this can format many web related file types
+    -- ['null-ls'] = { 'json', 'html', 'css', 'scss', 'javascriptreact', 'typescriptreact', 'javascript', 'typescript' },
+
   }
 })
 

--- a/doc/md/lsp.md
+++ b/doc/md/lsp.md
@@ -315,10 +315,9 @@ lsp.format_on_save({
     ['lua_ls'] = {'lua'},
     ['rust_analyzer'] = {'rust'},
     -- if you have a working setup with null-ls
-    -- you can specify filetypes it can format
-    -- for instance with prettier enabled, this can format many web related file types
-    -- ['null-ls'] = { 'json', 'html', 'css', 'scss', 'javascriptreact', 'typescriptreact', 'javascript', 'typescript' },
-
+    -- see https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/doc/BUILTINS.md#prettier 
+    -- for a set of filetypes useful for prettier null-ls integration
+    -- ['null-ls'] = { 'javascript', 'typescript' }
   }
 })
 


### PR DESCRIPTION
This proposes adding some more example filetypes that could be run through null-ls, that may be common for a web developer with prettier (formats json, javascriptreact (jsx) typescriptreact (tsx) and html, css, etc)

Certainly there is a balance with brevity in documenting so much of this, but thought it could help newcomers

