### PR TITLE
docs: fix mistake

### DIFF
--- a/doc/lsp-zero.txt
+++ b/doc/lsp-zero.txt
@@ -116,9 +116,9 @@ set_lsp_keymaps: ~
     Supported properties:
 
     * preserve_mappings: ~
-        Boolean. When set to false lsp-zero will not override any shortcut
-        that is already "taken". When set to true lsp-zero the LSP
-        shortcuts will be created no matter what.
+        Boolean, When set to true lsp-zero will not override any shortcut 
+        that is already "taken". When set to false lsp-zero will create LSP
+        shortcuts no matter what.
 
     * omit: ~
         List of strings. List of shorcuts you don't want lsp-zero to override.


### PR DESCRIPTION
Fixed mistake that misrepresented the actual behavior of set_lsp_kepmaps.preserve_mappings.