### PR TITLE
Update quick-recipes.md

### DIFF
--- a/doc/md/guides/quick-recipes.md
+++ b/doc/md/guides/quick-recipes.md
@@ -109,7 +109,7 @@ local rust_tools = require('rust-tools')
 
 rust_tools.setup({
   server = {
-    on_attach = function()
+    on_attach = function(_, bufnr)
       vim.keymap.set('n', '<leader>ca', rust_tools.hover_actions.hover_actions, {buffer = bufnr})
     end
   }


### PR DESCRIPTION
the callback function parameters are missing in on_attach for the rust-tools setup example.