### PR TITLE
documentation_window is meant to be true in minimal preset

### DIFF
--- a/doc/md/api-reference.md
+++ b/doc/md/api-reference.md
@@ -143,7 +143,7 @@ These are the settings it uses.
     set_extra_mappings = false,
     use_luasnip = true,
     set_format = true,
-    documentation_window = false,
+    documentation_window = true,
   },
 }
 ```


### PR DESCRIPTION
I think this was a typo as it conflicts with the code.