### PR TITLE
docs(install): update Mason run/build function

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Use your favorite plugin manager to install this plugin and all its lua dependen
     {                                      -- Optional
       'williamboman/mason.nvim',
       build = function()
-        pcall(vim.cmd, 'MasonUpdate')
+        pcall(vim.api.nvim_command, 'MasonUpdate')
       end,
     },
     {'williamboman/mason-lspconfig.nvim'}, -- Optional
@@ -136,7 +136,7 @@ use {
     {                                      -- Optional
       'williamboman/mason.nvim',
       run = function()
-        pcall(vim.cmd, 'MasonUpdate')
+        pcall(vim.api.nvim_command, 'MasonUpdate')
       end,
     },
     {'williamboman/mason-lspconfig.nvim'}, -- Optional
@@ -161,7 +161,7 @@ use {
 {                                      -- Optional
   'williamboman/mason.nvim',
   run = function()
-    pcall(vim.cmd, 'MasonUpdate')
+    pcall(vim.api.nvim_command, 'MasonUpdate')
   end,
 };
 {'williamboman/mason-lspconfig.nvim'}; -- Optional

--- a/README.md
+++ b/README.md
@@ -107,9 +107,7 @@ Use your favorite plugin manager to install this plugin and all its lua dependen
     {'neovim/nvim-lspconfig'},             -- Required
     {                                      -- Optional
       'williamboman/mason.nvim',
-      build = function()
-        pcall(vim.cmd, 'MasonUpdate')
-      end,
+      build = ':MasonUpdate',
     },
     {'williamboman/mason-lspconfig.nvim'}, -- Optional
 
@@ -135,9 +133,7 @@ use {
     {'neovim/nvim-lspconfig'},             -- Required
     {                                      -- Optional
       'williamboman/mason.nvim',
-      run = function()
-        pcall(vim.cmd, 'MasonUpdate')
-      end,
+      run = ':MasonUpdate',
     },
     {'williamboman/mason-lspconfig.nvim'}, -- Optional
 
@@ -160,9 +156,7 @@ use {
 {'neovim/nvim-lspconfig'};             -- Required
 {                                      -- Optional
   'williamboman/mason.nvim',
-  run = function()
-    pcall(vim.cmd, 'MasonUpdate')
-  end,
+  run = ':MasonUpdate',
 };
 {'williamboman/mason-lspconfig.nvim'}; -- Optional
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,9 @@ Use your favorite plugin manager to install this plugin and all its lua dependen
     {'neovim/nvim-lspconfig'},             -- Required
     {                                      -- Optional
       'williamboman/mason.nvim',
-      build = ':MasonUpdate',
+      build = function()
+        pcall(vim.cmd, 'MasonUpdate')
+      end,
     },
     {'williamboman/mason-lspconfig.nvim'}, -- Optional
 
@@ -133,7 +135,9 @@ use {
     {'neovim/nvim-lspconfig'},             -- Required
     {                                      -- Optional
       'williamboman/mason.nvim',
-      run = ':MasonUpdate',
+      run = function()
+        pcall(vim.cmd, 'MasonUpdate')
+      end,
     },
     {'williamboman/mason-lspconfig.nvim'}, -- Optional
 
@@ -156,7 +160,9 @@ use {
 {'neovim/nvim-lspconfig'};             -- Required
 {                                      -- Optional
   'williamboman/mason.nvim',
-  run = ':MasonUpdate',
+  run = function()
+    pcall(vim.cmd, 'MasonUpdate')
+  end,
 };
 {'williamboman/mason-lspconfig.nvim'}; -- Optional
 


### PR DESCRIPTION
The [Mason README](https://github.com/williamboman/mason.nvim#installation) recommends directly invoking `:MasonUpdate` in plugin manager build/run configuration.

I only noticed this due to following the lsp-zero installation instructions for lazy.nvim, installing the lua LSP, and being met with the following type warning for `pcall(vim.cmd, 'MasonUpdate')`:

```
Cannot assign `function|table` to parameter `fun(...any):...unknown`.  - `table` cannot match `fun(...any):...unknown`  - Type `table` cannot match `fun(...any):...unknown`
```

I was a little conflicted in submitting this PR, because I was happy to immediately see that lsp-zero is working perfectly, but I figure the config might as well pass the lua LSP's sniff test.

I am new to lua, so I am unaware of any adverse side effects to these changes.