### PR TITLE
fix: .extend_lspconfig() warning typo

### DIFF
--- a/lua/lsp-zero/api.lua
+++ b/lua/lsp-zero/api.lua
@@ -26,7 +26,7 @@ function M.extend_lspconfig()
 
   if Server.has_configs() then
     local msg = '[lsp-zero] Some language servers have been configured before\n'
-     .. 'you called the function .extened_lspconfig().\n\n'
+     .. 'you called the function .extend_lspconfig().\n\n'
      .. 'Solution: Go to the place where you use lspconfig for the first time.\n'
      .. 'Call the .extend_lspconfig() function before you setup the language server'
 


### PR DESCRIPTION
`.extened_lspconfig()` -> `.extend_lspconfig()`