### PR TITLE
Moving from tbl_islist to islist since tbl_islist will be depecrated in neovim version 0.12.

### DIFF
--- a/lua/lsp-zero/server.lua
+++ b/lua/lsp-zero/server.lua
@@ -14,6 +14,8 @@ local state = {
   omit_keys = {n = {}, i = {}, x = {}},
 }
 
+local islist = vim.islist or vim.tbl_islist
+
 function M.extend_lspconfig()
   if M.setup_done then
     return
@@ -406,7 +408,6 @@ function s.compose_fn(config_callback, user_callback)
 end
 
 function s.is_keyval(v)
-  local islist = vim.islist or vim.tbl_islist
   return type(v) == 'table' and not islist(v)
 end
 

--- a/lua/lsp-zero/server.lua
+++ b/lua/lsp-zero/server.lua
@@ -406,7 +406,7 @@ function s.compose_fn(config_callback, user_callback)
 end
 
 function s.is_keyval(v)
-  return type(v) == 'table' and not vim.tbl_islist(v)
+  return type(v) == 'table' and not vim.islist(v)
 end
 
 function s.tbl_merge(old_val, new_val)

--- a/lua/lsp-zero/server.lua
+++ b/lua/lsp-zero/server.lua
@@ -406,7 +406,8 @@ function s.compose_fn(config_callback, user_callback)
 end
 
 function s.is_keyval(v)
-  return type(v) == 'table' and not vim.islist(v)
+  local islist = vim.islist or vim.tbl_islist
+  return type(v) == 'table' and not islist(v)
 end
 
 function s.tbl_merge(old_val, new_val)


### PR DESCRIPTION
Warning is being given in neovim version 0.11, this solves the issue for those using it.